### PR TITLE
v1.1.0 - Custom input commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 A Streamlabs Chatbot script that will reply configure your bot to say hello to users saying hello.
 
+### Table of Contents
+* [Details](#details)
+* [Installation](#installation)
+    * [Installing Python 2.7.13](#install_python)
+    * [Setting Python for Streamlabs Chatbot](#configure_python)
+    * [How to Import into Streamlabs Chatbot](#import_script)
+* [How to Configure the Script](#configuration)
+    * [Permission](#configuration_permission)
+    * [Info](#configuration_info)
+    * [Cooldown](#configuration_cooldown)
+    * [Enable Custom Commands](#configuration_enable_commands)
+    * [Custom Commands](#configuration_commands)
+    * [Enable Logging](#configuration_logging)
+* [Supported Greetings](#greetings)
+
+<a name="details"/>
+
 ## Details
 ![Hello to you too](https://user-images.githubusercontent.com/11049883/47270459-190e7f00-d53a-11e8-8cc3-7029db9daf27.png)
 
@@ -9,7 +26,33 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 * The cooldown per user can be configured for a long duration (up to 4 hours).
 * This prevents your Chatbot from saying hello to people who were replying to someone else.
 
-## How to Import into Streamlabs Chatbot
+<a name="installation"/>
+
+## Installation
+
+<a name="install_python"/>
+
+### Installing Python 2.7.13
+* Streamlabs Chatbot scripts require that you have Python 2.7.13 installed on your local machine.
+* You can download Python 2.7.13 from the official [Python Software Foundation Download page](https://www.python.org/downloads/release/python-2713/).
+    * This is the direct link to the [Windows x86-64 MSI installer](https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi).
+* By default, the installer will save Python in `C:\Python27`
+
+<a name="configure_python"/>
+
+### Setting Python for Streamlabs Chatbot
+* In Streamlabs Chatbot, select the Scripts tab on the left menu.
+* Select the Settings button ![settings button](https://user-images.githubusercontent.com/11049883/47404591-eae89500-d71b-11e8-8a4e-89b3902a2541.png) in the top right corner of the tab.
+
+![global script settings](https://user-images.githubusercontent.com/11049883/47404567-d1dfe400-d71b-11e8-9628-c76fe6942bc4.png)
+* This will open up the Global Scrip Settings page for Streamlabs Chatbot
+* Click the **Pick Folder** under the **Python 2.7.13 Directory** section
+* This will open up a file explorer.  Select the folder of `\Python27\lib` folder.
+    * The default Python installation path is `C:\Python27\lib`
+
+<a name="import_script"/>
+
+### How to Import into Streamlabs Chatbot
 * Streamlabs Chatbot supports importing scripts as Zip files.
 * To download the `SLCBInternationalHello` Zip file:
     * Find all the releases by going to [releases tab](https://github.com/sktse/SLCBInternationalHello/releases)
@@ -20,7 +63,14 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 * Select the Import button ![import button](https://user-images.githubusercontent.com/11049883/47262592-be820e00-d4ba-11e8-9dae-38d84aa4c774.png) in the top right corner of the tab.
 * This will open up a file explorer.  Select the downloaded Zip file.
 
+<a name="configuration"/>
+
 ## How to Configure the Script
+
+![script settings](https://user-images.githubusercontent.com/11049883/47404903-30599200-d71d-11e8-8f77-e14362160144.png)
+
+<a name="configuration_permission"/>
+
 ### Permission
 * The Permission dropdown uses the standard Streamlab Chatbot permission levels.
 * The possible options are:
@@ -30,18 +80,42 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
     * `user_specific`
     * `editor`
 
+<a name="configuration_info"/>
+
 ### Info
 * The Info textbox is for when Permission is set to `user_specific`.
 * Enter the user name that you specifically want to have access to this script.
+
+<a name="configuration_cooldown"/>
 
 ### Cooldown
 * The Cooldown slider is to set the duration between replies to a specific user.
 * The Cooldown is set to a long period of time to stop the Chatbot from spamming the channel when _other_ people reply to a user initally greeting the chat.
 
+<a name="configuration_enable_commands"/>
+
+### Enable Custom Commands
+* The Enable Custom Commands checkbox turns on custom input commands in the **Custom Commands** section.
+* Enable this feature if you want the script to be triggered by your own custom commands.
+
+<a name="configuration_commands"/>
+
+### Custom Commands
+* The Custom Commands textox is for when Enable Custom Commands checkbox is turned on.
+* Enter your own custom input commands that will trigger a greeting response.
+* Your custom input commands must:
+    * Be a single word
+    * Be semi-colon separated for multiple custom commands
+* Example: When you enter `!hello;banana;heyo!`, when a user enters `!hello`, `banana`, or `heyo!` into chat, the script will reply with a greeting.
+
+<a name="configuration_logging"/>
+
 ### Enable Logging
 * The Enable Logging checkbox turns on very aggressive logging for this script.
-* Use to help develop and debug this script.
+* Enable this to help the development and debugging the script.
 * It is _not recommended_ you leave this on because it will make your log files large.
+
+<a name="greetings"/>
 
 ## Supported Greetings
 * This script currently will reply with the following greetings:
@@ -50,7 +124,8 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 | --- | --- | --- |
 | Hello | | English |
 | Greetings | | English |
-| Hi | | English
+| Hi | | English |
+| Hey | | English |
 | Allo | | French |
 | Bonjour | | French |
 | Top-o-the-morning | | English |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 * [Details](#details)
 * [Installation](#installation)
     * [Installing Python 2.7.13](#install_python)
-    * [Setting Python for Streamlabs Chatbot](#configure_python)
-    * [How to Import into Streamlabs Chatbot](#import_script)
-* [How to Configure the Script](#configuration)
+    * [Configuring Python for Streamlabs Chatbot](#configure_python)
+    * [Importing Scripts into Streamlabs Chatbot](#import_script)
+    * [Manually Uninstalling Scripts from Streamlabs Chatbot](#uninstall)
+* [Configuring the International Hello Script](#configuration)
     * [Permission](#configuration_permission)
     * [Info](#configuration_info)
     * [Cooldown](#configuration_cooldown)
@@ -40,7 +41,7 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 
 <a name="configure_python"/>
 
-### Setting Python for Streamlabs Chatbot
+### Configuring Python for Streamlabs Chatbot
 * In Streamlabs Chatbot, select the Scripts tab on the left menu.
 * Select the Settings button ![settings button](https://user-images.githubusercontent.com/11049883/47404591-eae89500-d71b-11e8-8a4e-89b3902a2541.png) in the top right corner of the tab.
 
@@ -52,22 +53,35 @@ A Streamlabs Chatbot script that will reply configure your bot to say hello to u
 
 <a name="import_script"/>
 
-### How to Import into Streamlabs Chatbot
+### Importing Scripts into Streamlabs Chatbot
 * Streamlabs Chatbot supports importing scripts as Zip files.
 * To download the `SLCBInternationalHello` Zip file:
-    * Find all the releases by going to [releases tab](https://github.com/sktse/SLCBInternationalHello/releases)
-    * For the version you want to use, click the ![Source code (zip)](https://user-images.githubusercontent.com/11049883/47276930-ee97e280-d588-11e8-870c-b6892fcaefe1.png) link to get the Zip file.
+    * Find the latest release by go to the [latest release page](https://github.com/sktse/SLCBInternationalHello/releases/latest)
+    * Find all the releases, including older versions, by going to [releases tab](https://github.com/sktse/SLCBInternationalHello/releases)
+    * For the version you want to use, click the ![SLCBInternationalHello.zip](https://user-images.githubusercontent.com/11049883/47473761-fbfbd980-d7e1-11e8-874d-276b50d835b6.png) link to download the Streamlabs Chatbot compatible Zip file.
 
 ![Streamlabs Chatbot Screenshot](https://user-images.githubusercontent.com/11049883/47262578-37349a80-d4ba-11e8-9812-c3354bebc13d.png)
 * In Streamlabs Chatbot, select the Scripts tab on the left menu.
 * Select the Import button ![import button](https://user-images.githubusercontent.com/11049883/47262592-be820e00-d4ba-11e8-9dae-38d84aa4c774.png) in the top right corner of the tab.
 * This will open up a file explorer.  Select the downloaded Zip file.
 
+<a name="uninstall"/>
+
+### Manually Uninstalling Scripts from Streamlabs Chatbot
+* In your File Explorer, go to the folder where Streamlabs Chatbot is installed.
+    * By default, Streamlabs Chatbot will be installed in `C:\Users\<your user name>\AppData\Roaming\Streamlabs\Streamlabs Chatbot`
+* From the Streamlabs Chatbot folder, go to `\Services\Scripts`.  This is where Streamlabs Chatbot installs all the scripts.
+* Delete any folders that start with `SLCBInternationalHello`.
+* In the Streamlabs Chatbot Scripts panel, click the Reload button ![refresh button](https://user-images.githubusercontent.com/11049883/47473935-ce636000-d7e2-11e8-89b6-86fed4c6c92c.png) to upload your scripts.
+* The International Hello script should now be removed. 
+
 <a name="configuration"/>
 
-## How to Configure the Script
+## Configuring the International Hello Script
 
 ![script settings](https://user-images.githubusercontent.com/11049883/47404903-30599200-d71d-11e8-8f77-e14362160144.png)
+
+* Click the name of the script to open up the configuration panel on the left side of Streamlabs Chatbot.
 
 <a name="configuration_permission"/>
 

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -219,6 +219,7 @@ def ReloadSettings(jsonData):
     SettingsFile = os.path.join(os.path.dirname(__file__), "Settings\settings.json")
     ScriptSettings.__dict__ = json.loads(jsonData)
     ScriptSettings.Save(SettingsFile, Parent, ScriptName)
+    log("Active script settings: {}".format(ScriptSettings.to_string()))
     initialize_input_greetings()
     return
 

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -36,6 +36,7 @@ Greetings = [
     "Hello",
     "Greetings",
     "Hi",
+    "Hey",
     "Allo",  # French
     "Bonjour",  # French
     "Top-o-the-morning",

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -20,7 +20,7 @@ ScriptName = "International Hello"
 Website = "https://github.com/sktse"
 Description = "Hello! Is it me you are looking for?"
 Creator = "sktse"
-Version = "1.0.1"
+Version = "1.1.0"
 
 #---------------------------
 #   Define Global Variables

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -125,7 +125,7 @@ def parse_custom_commands(commands_string):
     custom_commmands = []
     commands_array = commands_string.split(";")
     for command_string in commands_array:
-        cleaned_command_string = command_string.trim()
+        cleaned_command_string = command_string.strip()
         if cleaned_command_string:
             # The input is valid and is not empty.
             custom_commmands.append(cleaned_command_string)

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -98,10 +98,38 @@ def Init():
     SettingsFile = os.path.join(os.path.dirname(__file__), "Settings\settings.json")
     ScriptSettings = CommandSettings(SettingsFile)
 
+    initialize_input_greetings()
+    return
+
+
+def initialize_input_greetings():
+    InputGreetings = []
     for greeting in Greetings:
         InputGreetings.append(greeting.lower())
 
-    return
+    if not ScriptSettings.EnableCustomCommands:
+        return
+
+    custom_commands_string = ScriptSettings.CustomCommandStrings
+    log("Custom commands string:{}".format(custom_commands_string))
+
+    custom_commands = parse_custom_commands(custom_commands_string)
+    log("Parsed custom commands listed:{}".format(custom_commands))
+
+    for custom_command in custom_commands:
+        InputGreetings.append(custom_command)
+
+
+def parse_custom_commands(commands_string):
+    custom_commmands = []
+    commands_array = commands_string.split(";")
+    for command_string in commands_array:
+        cleaned_command_string = command_string.trim()
+        if cleaned_command_string:
+            # The input is valid and is not empty.
+            custom_commmands.append(cleaned_command_string)
+    return custom_commmands
+
 
 #---------------------------
 #   [Required] Execute Data / Process messages
@@ -182,6 +210,7 @@ def ReloadSettings(jsonData):
     SettingsFile = os.path.join(os.path.dirname(__file__), "Settings\settings.json")
     ScriptSettings.__dict__ = json.loads(jsonData)
     ScriptSettings.Save(SettingsFile, Parent, ScriptName)
+    initialize_input_greetings()
     return
 
 #---------------------------

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -104,10 +104,15 @@ def Init():
 
 
 def initialize_input_greetings():
-    InputGreetings = []
+    # Delete the contents of the array but NOT creating a new instance
+    # The pointer needs to be the same, but the contents nuked.
+    del InputGreetings[:]
     for greeting in Greetings:
         InputGreetings.append(greeting.lower())
 
+    log("Standard set of input greetings:{}".format(InputGreetings))
+
+    log("Is custom input commands enabled? {}".format(ScriptSettings.EnableCustomCommands))
     if not ScriptSettings.EnableCustomCommands:
         return
 
@@ -119,6 +124,8 @@ def initialize_input_greetings():
 
     for custom_command in custom_commands:
         InputGreetings.append(custom_command)
+
+    log("Extended set of input greetings:{}".format(InputGreetings))
     return
 
 
@@ -213,7 +220,6 @@ def ReloadSettings(jsonData):
     ScriptSettings.__dict__ = json.loads(jsonData)
     ScriptSettings.Save(SettingsFile, Parent, ScriptName)
     initialize_input_greetings()
-    log("Recognized input greetings:{}".format(InputGreetings))
     return
 
 #---------------------------

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -99,6 +99,7 @@ def Init():
     ScriptSettings = CommandSettings(SettingsFile)
 
     initialize_input_greetings()
+    log("Recognized input greetings:{}".format(InputGreetings))
     return
 
 
@@ -211,6 +212,7 @@ def ReloadSettings(jsonData):
     ScriptSettings.__dict__ = json.loads(jsonData)
     ScriptSettings.Save(SettingsFile, Parent, ScriptName)
     initialize_input_greetings()
+    log("Recognized input greetings:{}".format(InputGreetings))
     return
 
 #---------------------------

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -119,6 +119,7 @@ def initialize_input_greetings():
 
     for custom_command in custom_commands:
         InputGreetings.append(custom_command)
+    return
 
 
 def parse_custom_commands(commands_string):

--- a/SLCBInternationalHello/UI_Config.json
+++ b/SLCBInternationalHello/UI_Config.json
@@ -31,6 +31,20 @@
     "tooltip": "How long the reply should go on cooldown for",
     "group": "Core"
   },
+  "EnableCustomCommands": {
+    "type": "checkbox",
+    "value": false,
+    "label": "Enable Custom Commands",
+    "tooltip": "Turn on to allow greetings to be triggered by the custom commands.",
+    "group": "Core"
+  },
+  "CustomCommandStrings": {
+    "type": "textbox",
+    "value": "",
+    "label": "Custom Commands",
+    "tooltip": "Your custom commands to trigger greetings. Use only single words separated by semi-colons. Commands are case insensitive.",
+    "group": "Core"
+  },
   "Debug": {
     "type": "checkbox",
     "value": false,

--- a/SLCBInternationalHello/lib/Settings_Module.py
+++ b/SLCBInternationalHello/lib/Settings_Module.py
@@ -29,3 +29,14 @@ class CommandSettings(object):
             if parent:
                 parent.Log(script_name, "Failed to save settings to file.: {}".format(e))
         return
+
+    def to_string(self):
+        self_dict = {
+            "Permission": self.Permission,
+            "Info": self.Info,
+            "Cooldown": self.Cooldown,
+            "EnableCustomCommands": self.EnableCustomCommands,
+            "CustomCommandStrings": self.CustomCommandStrings,
+            "Debug": self.Debug
+        }
+        return str(self_dict)

--- a/SLCBInternationalHello/lib/Settings_Module.py
+++ b/SLCBInternationalHello/lib/Settings_Module.py
@@ -1,6 +1,7 @@
 import codecs
 import json
 
+
 class CommandSettings(object):
     def __init__(self, settingsfile=None):
         try:
@@ -10,6 +11,8 @@ class CommandSettings(object):
             self.Permission = "everyone"
             self.Info = ""
             self.Cooldown = 60
+            self.EnableCustomCommands = False
+            self.CustomCommandStrings = ""
             self.Debug = False
 
     def Reload(self, jsondata):


### PR DESCRIPTION
## Description
* Adds the ability to add custom input commands to trigger a greeting response.
    * Custom input commands are set with a semi-colon separated string.
    * Each custom command can only be one word.
    * This is because the command currently only checks the first word of every message.
* Added "Hey" as a standard set of greetings.
* Added more installation details in the README.
* Increased logging.
