### PR TITLE
Fixes initial settings loading.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ SLCBInternationalHello/Settings/settings.json
 
 # Testing temp files
 test-reports/
-tests/settings_files/settings-test.json
-tests/settings_files/settings-test.js
+tests/settings_files/settings-saved.json
+tests/settings_files/settings-saved.js
 
 # Release building
 tmp/

--- a/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
+++ b/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py
@@ -60,7 +60,7 @@ def Init():
 
     #   Load settings
     settings_file = os.path.join(os.path.dirname(__file__), "Settings\settings.json")
-    script_settings = ScriptSettings(settings_file)
+    script_settings.initialize(settings_file)
 
     initialize_script()
     return

--- a/SLCBInternationalHello/lib/settings.py
+++ b/SLCBInternationalHello/lib/settings.py
@@ -33,15 +33,19 @@ class ScriptSettings(object):
         "Debug": False,
     }
 
-    def __init__(self, settingsfile=None):
+    def __init__(self, settings_file=None):
+        if settings_file:
+            self.initialize(settings_file)
+
+        self.initialize_defaults()
+
+    def initialize(self, settings_file):
         try:
-            with codecs.open(settingsfile, encoding="utf-8-sig", mode="r") as f:
+            with codecs.open(settings_file, encoding="utf-8-sig", mode="r") as f:
                 self.__dict__ = json.load(f, encoding="utf-8")
         except:
             # Expect the open to fail if the file does not exist
             pass
-
-        self.initialize_defaults()
 
     def reload(self, jsondata):
         self.__dict__ = json.loads(jsondata, encoding="utf-8")

--- a/tests/settings_files/settings-test.json
+++ b/tests/settings_files/settings-test.json
@@ -1,0 +1,11 @@
+﻿{
+  "Info": "Banana",
+  "EnableCustomCommands": true,
+  "CustomOutputPercentage": 15,
+  "CustomCommandStrings": "!hello;morning;evening;banana",
+  "Permission": "everyone",
+  "CustomOutputStrings": "Well hello Mr. Fancy Pants!;Say 'hello' to my little friend!;Hello, my name is Inigo Montoya. You killed my father. Prepare to die.;Heeeeere's Johnny!;You had me at 'Hello'.;You talkin' to me?;Live long and prosper.;Here's looking at you, kid.;Frankly, my dear, I don't give a damn.;Shane. Shane. Come back!;Mrs. Robinson, you're trying to seduce me. Aren't you?;Yo, Adrian!;May the Force be with you.;That'll do, pig, that'll do.;Hello, is it me you are looking for?;",
+  "Cooldown": 10,
+  "Debug": true,
+  "EnableCustomOutput": false
+}

--- a/tests/settings_tests.py
+++ b/tests/settings_tests.py
@@ -57,16 +57,34 @@ class ScriptSettingsTests(TestCase):
         self.assertEqual(settings.CustomOutputPercentage, 10)
         self.assertEqual(settings.CustomOutputStrings, self.expected_custom_commands_strings)
 
+    def test_initialize__loads_file(self):
+        settings = ScriptSettings()
+        # This is already verified to load the default values
+
+        json_path = os.path.join(os.path.dirname(__file__), "settings_files", "settings-test.json")
+        settings.initialize(json_path)
+
+        # The settings will have the values from the JSON file.
+        self.assertEqual(settings.Permission, "everyone")
+        self.assertEqual(settings.Info, "Banana")
+        self.assertEqual(settings.Cooldown, 10)
+        self.assertTrue(settings.EnableCustomCommands)
+        self.assertEqual(settings.CustomCommandStrings, "!hello;morning;evening;banana")
+        self.assertFalse(settings.EnableCustomOutput)
+        self.assertEqual(settings.CustomOutputPercentage, 15)
+        self.assertEqual(settings.CustomOutputStrings, self.expected_custom_commands_strings)
+        self.assertTrue(settings.Debug)
+
     def test_save__saves_file(self):
         settings = ScriptSettings()
         mock_parent = Mock()
 
-        json_path = os.path.join(os.path.dirname(__file__), "settings_files", "settings-test.json")
+        json_path = os.path.join(os.path.dirname(__file__), "settings_files", "settings-saved.json")
         settings.save(json_path, mock_parent, "Ash")
         mock_parent.assert_not_called()
 
         # Saving creates the JSON and javascript files.
-        js_path = os.path.join(os.path.dirname(__file__), "settings_files", "settings-test.js")
+        js_path = os.path.join(os.path.dirname(__file__), "settings_files", "settings-saved.js")
         self.assertTrue(os.path.isfile(json_path))
         self.assertTrue(os.path.isfile(js_path))
 


### PR DESCRIPTION
## Description

* The settings file was not being loaded up correctly on initial script loading.
* It was just loading the default values with an empty constructor.
* The initialization on the `Init()` function was not sticking.
* The fix is to reconstruct the settings class as an initializable single instance object.

## Deployment Steps
If applicable, complete the checklist for deployment.
- [ ] Update the `Version` property in [SLCBInternationalHello_StreamlabsSystem](https://github.com/sktse/SLCBInternationalHello/blob/master/SLCBInternationalHello/SLCBInternationalHello_StreamlabsSystem.py)
- [ ] Download the release `zip` file from the  artifacts of the `master` build in [CircleCI](https://circleci.com/gh/sktse/SLCBInternationalHello/tree/master)
- [ ] Create a new release in [Github](https://github.com/sktse/SLCBInternationalHello/releases)
- [ ] Fill out the release notes.
- [ ] Upload the `zip` file to the release.
- [ ] Update the [README.md](https://github.com/sktse/SLCBInternationalHello/blob/master/README.md) version and download link.
